### PR TITLE
Fix Flagger for Linkerd 2.13

### DIFF
--- a/infrastructure/flagger/release.yaml
+++ b/infrastructure/flagger/release.yaml
@@ -21,3 +21,5 @@ spec:
     meshProvider: linkerd
     metricsServer: http://prometheus.linkerd-viz:9090
     selectorLabels: app,name,app.kubernetes.io/name,service
+    linkerdAuthPolicy:
+      create: true


### PR DESCRIPTION
Add an `AuthorizationPolicy` which allows Flagger to access the Prometheus server in the `linkerd-viz` namespace which is blocked by default starting with Linkerd 2.13.